### PR TITLE
Corrected comment

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/DPAPI-HowTO/cs/sample.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/DPAPI-HowTO/cs/sample.cs
@@ -186,7 +186,7 @@ public class MemoryProtectionSample
             throw new IOException("Could not read the stream.");
         }
 
-        // Return the length that was written to the stream. 
+        // Return the unencrypted data as byte array. 
         return outBuffer;
 
     }


### PR DESCRIPTION
The method returns the unprotected byte array from the stream. Most likely a copy-paste error.

# Corrected comment

## Summary

Just changed a code comment.

## Suggested Reviewers

Initial file owner: @yishengjin1413 
